### PR TITLE
[fix] Adjust Airship image build jobs for opendev

### DIFF
--- a/images/airship/JenkinsfilePromenade
+++ b/images/airship/JenkinsfilePromenade
@@ -97,7 +97,7 @@ vms {
                 IMAGE_TAG=env.GERRIT_NEWREV
                 IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
             }
-            gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-${JOB_BASE_NAME}","${IMAGE_TAG}","")
+            gerrit.cloneToBranch("https://opendev.org/airship/${JOB_BASE_NAME}","${IMAGE_TAG}","")
 
             if(GERRIT_EVENT_TYPE != 'change-merged') {
                 gerrit.rebase()

--- a/images/airship/armada/Jenkinsfile
+++ b/images/airship/armada/Jenkinsfile
@@ -85,13 +85,13 @@ vms {
 
     stage('Checkout Promenade'){
         node("${NODE_BASE}-build"){
-            gerrit.clone("https://git.openstack.org/openstack/airship-promenade", "*/master")
+            gerrit.clone("https://opendev.org/airship/promenade", "*/master")
             if(env.GERRIT_NEWREV){
                 echo ("${GERRIT_NEWREV} is being used to override refspec: ${GERRIT_REFSPEC}")
                 IMAGE_TAG=env.GERRIT_NEWREV
                 IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
             }
-            gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-${JOB_BASE_NAME}", IMAGE_TAG,"${JOB_BASE_NAME}")
+            gerrit.cloneToBranch("https://opendev.org/airship/${JOB_BASE_NAME}", IMAGE_TAG,"${JOB_BASE_NAME}")
             if(GERRIT_EVENT_TYPE != 'change-merged') {
                 sh '''git config user.email "attcomdev.jenkins@gmail.com"
                     git config user.name "Jenkins"

--- a/images/airship/deckhand/Jenkinsfile
+++ b/images/airship/deckhand/Jenkinsfile
@@ -17,7 +17,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG="${GERRIT_NEWREV}"
         }
         IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}.${BUILD_NUMBER}"
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-${JOB_BASE_NAME}", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/${JOB_BASE_NAME}", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
             sh '''git config user.email "airship.jenkins@gmail.com"
                   git config user.name "Jenkins"

--- a/images/airship/drydock/Jenkinsfile
+++ b/images/airship/drydock/Jenkinsfile
@@ -18,7 +18,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG=env.GERRIT_NEWREV
             IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
         }
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-drydock", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/drydock", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
             sh '''git config user.email "airship.jenkins@gmail.com"
                   git config user.name "Jenkins"

--- a/images/airship/maas/Jenkinsfile
+++ b/images/airship/maas/Jenkinsfile
@@ -18,7 +18,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG=env.GERRIT_NEWREV
             IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
         }
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-maas", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/maas", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
               sh '''git config user.email "airship.jenkins@gmail.com"
                     git config user.name "Jenkins"

--- a/images/airship/pegleg/Jenkinsfile
+++ b/images/airship/pegleg/Jenkinsfile
@@ -18,7 +18,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG=env.GERRIT_NEWREV
             IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
         }
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-pegleg", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/pegleg", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
               gerrit.rebase()
         }

--- a/images/airship/promenade/promenade/Jenkinsfile
+++ b/images/airship/promenade/promenade/Jenkinsfile
@@ -92,7 +92,7 @@ vms {
                             relativeTargetDir: ""]],
                             submoduleCfg: [],
                             userRemoteConfigs: [[refspec: '${GERRIT_REFSPEC}',
-                                                 url: "https://git.openstack.org/openstack/airship-${JOB_BASE_NAME}"]]]
+                                                 url: "https://opendev.org/airship/${JOB_BASE_NAME}"]]]
             if(GERRIT_EVENT_TYPE != 'change-merged') {
                 sh '''git config user.email "attcomdev.jenkins@gmail.com"
                     git config user.name "Jenkins"

--- a/images/airship/promenade/resiliency/Jenkinsfile
+++ b/images/airship/promenade/resiliency/Jenkinsfile
@@ -54,7 +54,7 @@ def promenade_stage = { item ->
 vm(NODE_NAME, NODE_TMPL) {
 
     stage('Prepare') {
-        gerrit.clone("https://git.openstack.org/openstack/airship-promenade", GERRIT_REFSPEC)
+        gerrit.clone("https://opendev.org/airship/promenade", GERRIT_REFSPEC)
 
         ansiColor('xterm') {
             sh "${WORKSPACE}/tools/setup_gate.sh"

--- a/images/airship/seed-mtn29.groovy
+++ b/images/airship/seed-mtn29.groovy
@@ -1,56 +1,56 @@
 import groovy.json.JsonSlurper
 //This will change once all images/airship/xxx are deprecated
-folder("images/airship/mtn29/airship-shipyard")
-folder("images/airship/mtn29/airship-maas")
+folder("images/airship/mtn29/shipyard")
+folder("images/airship/mtn29/maas")
 folder("images/airship/patchset")
 def imagesJson = '''{ "github":[{
-                               "repo":"https://git.openstack.org/openstack/airship-shipyard",
-                               "directory":"images/airship/mtn29/airship-shipyard/shipyard",
+                               "repo":"https://opendev.org/airship/shipyard",
+                               "directory":"images/airship/mtn29/shipyard/shipyard",
                                "image":"shipyard",
                                "name":"shipyard"
                             },{
-                               "repo":"https://git.openstack.org/openstack/airship-shipyard",
-                                "directory":"images/airship/mtn29/airship-shipyard/airflow",
+                               "repo":"https://opendev.org/airship/shipyard",
+                                "directory":"images/airship/mtn29/shipyard/airflow",
                                 "image":"airflow",
                                 "name":"shipyard"
                             },{
-                               "repo":"https://git.openstack.org/openstack/airship-drydock",
-                                "directory":"images/airship/mtn29/airship-drydock",
+                               "repo":"https://opendev.org/airship/drydock",
+                                "directory":"images/airship/mtn29/drydock",
                                 "image":"drydock",
                                 "name":"drydock"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/mtn29/airship-maas/maas-region-controller",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/mtn29/maas/maas-region-controller",
                                 "image":"maas-region-controller",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/mtn29/airship-maas/maas-rack-controller",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/mtn29/maas/maas-rack-controller",
                                 "image":"maas-rack-controller",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/mtn29/airship-maas/sstream-cache",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/mtn29/maas/sstream-cache",
                                 "image":"sstream-cache",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-deckhand",
-                                "directory":"images/airship/mtn29/airship-deckhand",
+                                "repo":"https://opendev.org/airship/deckhand",
+                                "directory":"images/airship/mtn29/deckhand",
                                 "image":"deckhand",
                                 "name":"deckhand"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-armada",
-                                "directory":"images/airship/mtn29/airship-armada",
+                                "repo":"https://opendev.org/airship/armada",
+                                "directory":"images/airship/mtn29/armada",
                                 "image":"armada",
                                 "name":"armada"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-pegleg",
-                                "directory":"images/airship/mtn29/airship-pegleg",
+                                "repo":"https://opendev.org/airship/pegleg",
+                                "directory":"images/airship/mtn29/pegleg",
                                 "image":"pegleg",
                                 "name":"pegleg"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-promenade",
-                                "directory":"images/airship/mtn29/airship-promenade",
+                                "repo":"https://opendev.org/airship/promenade",
+                                "directory":"images/airship/mtn29/promenade",
                                 "image":"promenade",
                                 "name":"promenade"
                             }]}'''
@@ -114,7 +114,7 @@ for (entry in object.github) {
                 gerritProjects {
                     gerritProject {
                         compareType('PLAIN')
-                        pattern("openstack/airship-${entry.name}")
+                        pattern("airship/${entry.name}")
                         branches {
                             branch {
                                 compareType("ANT")
@@ -143,8 +143,8 @@ for (entry in object.github) {
 }
 
 imagesJson = '''{ "github":[{
-                                "repo":"https://git.openstack.org/openstack/airship-promenade",
-                                "directory":"images/airship/patchset/airship-promenade",
+                                "repo":"https://opendev.org/airship/promenade",
+                                "directory":"images/airship/patchset/promenade",
                                 "image":"multi-node-promenade",
                                 "name":"promenade",
                                 "jenkinsfile_loc":"JenkinsfilePromenade"
@@ -184,7 +184,7 @@ for (entry in object.github) {
                 gerritProjects {
                     gerritProject {
                         compareType('PLAIN')
-                        pattern("openstack/airship-${entry.name}")
+                        pattern("airship/${entry.name}")
                         branches {
                             branch {
                                 compareType("ANT")

--- a/images/airship/seed.groovy
+++ b/images/airship/seed.groovy
@@ -3,57 +3,57 @@ import groovy.json.JsonSlurper
 folder("images")
 folder("images/airship")
 folder("images/airship/update")
-folder("images/airship/update/airship-shipyard")
-folder("images/airship/update/airship-maas")
+folder("images/airship/update/shipyard")
+folder("images/airship/update/maas")
 folder("images/airship/patchset")
 def imagesJson = '''{ "github":[{
-                               "repo":"https://git.openstack.org/openstack/airship-shipyard",
-                               "directory":"images/airship/update/airship-shipyard/shipyard",
+                               "repo":"https://opendev.org/airship/shipyard",
+                               "directory":"images/airship/update/shipyard/shipyard",
                                "image":"shipyard",
                                "name":"shipyard"
                             },{
-                               "repo":"https://git.openstack.org/openstack/airship-shipyard",
-                                "directory":"images/airship/update/airship-shipyard/airflow",
+                               "repo":"https://opendev.org/airship/shipyard",
+                                "directory":"images/airship/update/shipyard/airflow",
                                 "image":"airflow",
                                 "name":"shipyard"
                             },{
-                               "repo":"https://git.openstack.org/openstack/airship-drydock",
-                                "directory":"images/airship/update/airship-drydock",
+                               "repo":"https://opendev.org/airship/drydock",
+                                "directory":"images/airship/update/drydock",
                                 "image":"drydock",
                                 "name":"drydock"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/update/airship-maas/maas-region-controller",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/update/maas/maas-region-controller",
                                 "image":"maas-region-controller",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/update/airship-maas/maas-rack-controller",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/update/maas/maas-rack-controller",
                                 "image":"maas-rack-controller",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-maas",
-                                "directory":"images/airship/update/airship-maas/sstream-cache",
+                                "repo":"https://opendev.org/airship/maas",
+                                "directory":"images/airship/update/maas/sstream-cache",
                                 "image":"sstream-cache",
                                 "name":"maas"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-deckhand",
-                                "directory":"images/airship/update/airship-deckhand",
+                                "repo":"https://opendev.org/airship/deckhand",
+                                "directory":"images/airship/update/deckhand",
                                 "image":"deckhand",
                                 "name":"deckhand"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-armada",
-                                "directory":"images/airship/update/airship-armada",
+                                "repo":"https://opendev.org/airship/armada",
+                                "directory":"images/airship/update/armada",
                                 "image":"armada",
                                 "name":"armada"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-pegleg",
-                                "directory":"images/airship/update/airship-pegleg",
+                                "repo":"https://opendev.org/airship/pegleg",
+                                "directory":"images/airship/update/pegleg",
                                 "image":"pegleg",
                                 "name":"pegleg"
                             },{
-                                "repo":"https://git.openstack.org/openstack/airship-promenade",
-                                "directory":"images/airship/update/airship-promenade",
+                                "repo":"https://opendev.org/airship/promenade",
+                                "directory":"images/airship/update/promenade",
                                 "image":"promenade",
                                 "name":"promenade"
                             }]}'''
@@ -94,7 +94,7 @@ for (entry in object.github) {
                 gerritProjects {
                     gerritProject {
                         compareType('PLAIN')
-                        pattern("openstack/airship-${entry.name}")
+                        pattern("airship/${entry.name}")
                         branches {
                             branch {
                                 compareType("ANT")
@@ -128,8 +128,8 @@ for (entry in object.github) {
 }
 
 imagesJson = '''{ "github":[{
-                                "repo":"https://git.openstack.org/openstack/airship-promenade",
-                                "directory":"images/airship/patchset/airship-promenade",
+                                "repo":"https://opendev.org/airship/promenade",
+                                "directory":"images/airship/patchset/promenade",
                                 "image":"multi-node-promenade",
                                 "name":"promenade",
                                 "jenkinsfile_loc":"JenkinsfilePromenade"
@@ -171,7 +171,7 @@ for (entry in object.github) {
                 gerritProjects {
                     gerritProject {
                         compareType('PLAIN')
-                        pattern("openstack/airship-${entry.name}")
+                        pattern("airship/${entry.name}")
                         branches {
                             branch {
                                 compareType("ANT")

--- a/images/airship/shipyard/Jenkinsfile
+++ b/images/airship/shipyard/Jenkinsfile
@@ -18,7 +18,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG=env.GERRIT_NEWREV
             IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
         }
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-${JOB_BASE_NAME}", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/${JOB_BASE_NAME}", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
             sh '''git config user.email "airship.jenkins@gmail.com"
                   git config user.name "Jenkins"

--- a/images/airship/shipyard/airflow/Jenkinsfile
+++ b/images/airship/shipyard/airflow/Jenkinsfile
@@ -18,7 +18,7 @@ vm(NODE_NAME, NODE_TMPL) {
             IMAGE_TAG=env.GERRIT_NEWREV
             IMAGE="${DOCKER_REGISTRY}/${IMAGE_PREFIX}/${JOB_BASE_NAME}:${IMAGE_TAG}"
         }
-        gerrit.cloneToBranch("https://git.openstack.org/openstack/airship-shipyard", IMAGE_TAG,"")
+        gerrit.cloneToBranch("https://opendev.org/airship/shipyard", IMAGE_TAG,"")
         if(GERRIT_EVENT_TYPE != 'change-merged') {
             sh '''git config user.email "airship.jenkins@gmail.com"
                   git config user.name "Jenkins"


### PR DESCRIPTION
The Airship project (along with the other OpenStack Foundation
projects) moved to new git hosting infrastructure with a new
domain name - opendev.org.  This change adjusts the cicd project
to build images from these new locations.  As part of this change,
the 'airship-' prefixes have been removed from project names, and
the projects instead live under an /airship namespace (instead
of the previous /openstack).